### PR TITLE
feat: Added support of content overrides

### DIFF
--- a/content_overrides.go
+++ b/content_overrides.go
@@ -62,3 +62,16 @@ func (rhsmClient *RHSMClient) GetContentOverrides() ([]ContentOverride, error) {
 
 	return contentOverrides, nil
 }
+
+// createMapFromContentOverrides creates map with content overrides from list of
+// content overrides returned from candlepin server
+func createMapFromContentOverrides(contentOverrides []ContentOverride) map[string]map[string]string {
+	mapContentOverrides := make(map[string]map[string]string)
+	for _, contentOverride := range contentOverrides {
+		if _, exist := mapContentOverrides[contentOverride.ContentLabel]; !exist {
+			mapContentOverrides[contentOverride.ContentLabel] = make(map[string]string)
+		}
+		mapContentOverrides[contentOverride.ContentLabel][contentOverride.Name] = contentOverride.Value
+	}
+	return mapContentOverrides
+}

--- a/content_test.go
+++ b/content_test.go
@@ -94,7 +94,8 @@ func TestWriteRepoFile(t *testing.T) {
 		t.Fatalf("unable to setup testing rhsm client: %s", err)
 	}
 
-	err = rhsmClient.generateRepoFileFromInstalledEntitlementCerts()
+	contentOverrides := make(map[string]map[string]string)
+	err = rhsmClient.generateRepoFileFromInstalledEntitlementCerts(contentOverrides)
 
 	if err != nil {
 		t.Fatalf("unable to generate '%s': %s", testingFiles.YumRepoFilePath, err)
@@ -128,7 +129,8 @@ func TestWriteRepoFileNoEntCert(t *testing.T) {
 		t.Fatalf("unable to setup testing rhsm client: %s", err)
 	}
 
-	err = rhsmClient.generateRepoFileFromInstalledEntitlementCerts()
+	contentOverrides := make(map[string]map[string]string)
+	err = rhsmClient.generateRepoFileFromInstalledEntitlementCerts(contentOverrides)
 
 	if err != nil {
 		t.Fatalf("when no entitlement certificate installed, error returned: %s", err)


### PR DESCRIPTION
* When registration using activation keys is used, then it is possible that some activation key has defined some content overrides (e.g. some repository is enabled). Thus, rhsm2 service has to get current content overrides during registration, when at least one activation key is used.
* When some content overrides are received, then this content overrides are used for generating `redhat.repo`
* When username and password is used, then rhsm2 does not try to get content overrides, because it is useless for this scenario. There could not be any content overrides defined for just created consumer, when username and password is used for registration
* TODO:
  * Write content overrides to some cache file