### PR TITLE
feat: Added option to set command of UserAgent HTTP header

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/henvic/httpretty"
+	"github.com/jirihnidek/rhsm2/constants"
 	"github.com/rs/zerolog/log"
 	"io"
 	"net"
@@ -46,6 +47,35 @@ type RHSMConnection struct {
 // createCorrelationId
 func createCorrelationId() string {
 	return uuid.New().String()
+}
+
+// UserAgentInfo holds information about current client connected
+// to candlepin server
+type UserAgentInfo struct {
+	BaseString string
+	Command    string
+}
+
+var (
+
+	// UserAgent is the HTTP header used in each HTTP request
+	UserAgent = UserAgentInfo{
+		"RHSM/" + constants.ApiVersion,
+		"",
+	}
+)
+
+// SetUserAgentCmd set command of UserAgent
+func SetUserAgentCmd(userAgentCmd string) {
+	UserAgent.Command = userAgentCmd
+}
+
+// String returns textual representation of UserAgent
+func (userAgent UserAgentInfo) String() string {
+	if userAgent.Command != "" {
+		return userAgent.BaseString + " (cmd=" + userAgent.Command + ")"
+	}
+	return userAgent.BaseString
 }
 
 // request tries to call HTTP request to candlepin server
@@ -99,7 +129,7 @@ func (connection *RHSMConnection) request(
 	}
 
 	// Add basic headers
-	req.Header.Add("User-Agent", "sub-man 0.1")
+	req.Header.Add("User-Agent", UserAgent.String())
 
 	// If "Accept" header is not specified, then request JSON in response
 	var acceptExists = false

--- a/connection_test.go
+++ b/connection_test.go
@@ -16,6 +16,26 @@ func TestCreateXCorrelationID(t *testing.T) {
 	}
 }
 
+// TestUserAgentString test the case, when client has not set command of UserAgent
+// String() method should return default value
+func TestUserAgentString(t *testing.T) {
+	userAgentStr := UserAgent.String()
+	expectedUserAgent := "RHSM/2.0"
+	if userAgentStr != expectedUserAgent {
+		t.Fatalf("expected UserAgent: \"%s\", got: \"%s\"", expectedUserAgent, userAgentStr)
+	}
+}
+
+// TestSetUserAgentCmd test the case, when client set command of UserAgent
+func TestSetUserAgentCmd(t *testing.T) {
+	SetUserAgentCmd("foo-cmd")
+	userAgentStr := UserAgent.String()
+	expectedUserAgent := "RHSM/2.0 (cmd=foo-cmd)"
+	if userAgentStr != expectedUserAgent {
+		t.Fatalf("expected UserAgent: \"%s\", got: \"%s\"", expectedUserAgent, userAgentStr)
+	}
+}
+
 // TestCreateHTTPsClientProxyFromConf test the case, when proxy server
 // is used. The /status endpoint is used for testing
 func TestCreateHTTPsClientProxyFromConf(t *testing.T) {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,0 +1,6 @@
+package constants
+
+var (
+	// ApiVersion is string containing version of RHSM API
+	ApiVersion = "2.0"
+)


### PR DESCRIPTION
* RHSM client sends UserAgent HTTP header in each HTTP request, and it is possible to set cmd of UserAgent header using public method SetUserAgentCmd()
* Added two unit tests for this new feature