### PR TITLE
Register options

### DIFF
--- a/register.go
+++ b/register.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -333,10 +334,26 @@ func (rhsmClient *RHSMClient) RegisterUsernamePasswordOrg(
 	username *string,
 	password *string,
 	org *string,
-	environments []string,
+	options *map[string]string,
 	clientInfo *ClientInfo,
 ) (*ConsumerData, error) {
 	var registerOptions RegisterOptions
+	var environments []string
+
+	// Parse all options first, when some provided
+	if options != nil {
+		for option, value := range *options {
+			switch option {
+			case "environments":
+				environments = strings.Split(value, ",")
+				break
+			default:
+				log.Warn().Msgf("unknown option: %s", option)
+				break
+			}
+		}
+	}
+
 	registerOptions.username = username
 	registerOptions.password = password
 	registerOptions.organization = org

--- a/register.go
+++ b/register.go
@@ -314,6 +314,7 @@ func (rhsmClient *RHSMClient) registerSystem(
 func (rhsmClient *RHSMClient) RegisterOrgActivationKeys(
 	org *string,
 	activationKeys []string,
+	options *map[string]string,
 	clientInfo *ClientInfo,
 ) (*ConsumerData, error) {
 	var registerOptions RegisterOptions
@@ -329,16 +330,16 @@ func (rhsmClient *RHSMClient) RegisterOrgActivationKeys(
 	return rhsmClient.registerSystem(&registerOptions, clientInfo)
 }
 
-// RegisterUsernamePasswordOrg tries to register system using organization id, username and password
-func (rhsmClient *RHSMClient) RegisterUsernamePasswordOrg(
+// RegisterUsernamePassword tries to register system using username and password
+func (rhsmClient *RHSMClient) RegisterUsernamePassword(
 	username *string,
 	password *string,
-	org *string,
 	options *map[string]string,
 	clientInfo *ClientInfo,
 ) (*ConsumerData, error) {
 	var registerOptions RegisterOptions
 	var environments []string
+	var org string
 
 	// Parse all options first, when some provided
 	if options != nil {
@@ -346,17 +347,17 @@ func (rhsmClient *RHSMClient) RegisterUsernamePasswordOrg(
 			switch option {
 			case "environments":
 				environments = strings.Split(value, ",")
-				break
+			case "org":
+				org = value
 			default:
 				log.Warn().Msgf("unknown option: %s", option)
-				break
 			}
 		}
 	}
 
 	registerOptions.username = username
 	registerOptions.password = password
-	registerOptions.organization = org
+	registerOptions.organization = &org
 	registerOptions.environments = &environments
 
 	if clientInfo == nil {

--- a/register_test.go
+++ b/register_test.go
@@ -359,7 +359,7 @@ func TestRegisterUsernamePasswordOrgEnvironments(t *testing.T) {
 	username := "admin"
 	password := "admin"
 	org := "donaldduck"
-	environemts := []string{"env-id-1", "env-id-2"}
+	options := map[string]string{"environments": "env-id-1,env-id-2", "foo": "bar"}
 
 	server := httptest.NewTLSServer(
 		// It is expected that Register() method will call only
@@ -423,7 +423,7 @@ func TestRegisterUsernamePasswordOrgEnvironments(t *testing.T) {
 	// TODO: try to use secure connection
 	rhsmClient.RHSMConf.Server.Insecure = true
 
-	consumer, err := rhsmClient.RegisterUsernamePasswordOrg(&username, &password, &org, environemts, nil)
+	consumer, err := rhsmClient.RegisterUsernamePasswordOrg(&username, &password, &org, &options, nil)
 	if err != nil {
 		t.Fatalf("registration failed: %s", err)
 	}


### PR DESCRIPTION
* Changed environments argument to option to be able to
   carry more registration options in the future
* Added register option to `RegisterOrgActivationKeys()`,
   but it is not used for anything at this moment
* Renamed `RegisterOrgUsernamePassword()` to
   `RegisterUsernamePassword()`, because most of use cases
   uses only username and password.
* There are only two mandatory arguments (username & password)
   The organization ID is not mandatory anymore. It can be specified
   in argument called options using `options["org"] = "org_id"`
* Added one unit test for the case, when only username and password
   is used for registration
* Modified other unit tests