### PR TITLE
fix: Do not ignore error from Close() method

### DIFF
--- a/syspurpose_test.go
+++ b/syspurpose_test.go
@@ -57,7 +57,12 @@ func TestCorruptedSystemPurposeFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create temporary %s file for testing", corruptedSyspurposeFilePath)
 	}
-	defer syspurposeFile.Close()
+	defer func() {
+		err = syspurposeFile.Close()
+		if err != nil {
+			t.Fatalf("unable to close %s file for testing", corruptedSyspurposeFilePath)
+		}
+	}()
 	corruptedContent := "[{]}foo:bar/%&@#"
 	_, err = syspurposeFile.Write([]byte(corruptedContent))
 	if err != nil {

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -41,7 +41,11 @@ func isDirEmpty(name *string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
+	defer func() {
+		// The error of closing could be ignored in this case,
+		// because we only read content of directory
+		_ = f.Close()
+	}()
 
 	_, err = f.Readdir(1)
 	if err == io.EOF {


### PR DESCRIPTION
* We used `defer writer.Close()` and we ignored error returned from `Close()` method. This could lead to loosing important error