### PR TITLE
feat: Added method for getting list of server endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,12 +92,16 @@ func createRHSMClient(confFilePath *string) (*RHSMClient, error) {
 	return rhsmClient, nil
 }
 
+// consumerPEMFile returns a full path to a PEM file in the consumer certificate directory
+// fileName: name of the PEM file to locate
 func (rhsmClient *RHSMClient) consumerPEMFile(fileName string) *string {
 	consumerCerDir := rhsmClient.RHSMConf.RHSM.ConsumerCertDir
 	consumerCertPath := filepath.Join(consumerCerDir, fileName)
 	return &consumerCertPath
 }
 
+// entitlementPEMFile returns a full path to a PEM file in the entitlement certificate directory
+// fileName: name of the PEM file to locate
 func (rhsmClient *RHSMClient) entitlementPEMFile(fileName string) *string {
 	entCerDir := rhsmClient.RHSMConf.RHSM.EntitlementCertDir
 	entCertPath := filepath.Join(entCerDir, fileName)

--- a/status.go
+++ b/status.go
@@ -7,6 +7,67 @@ import (
 	"net/http"
 )
 
+// RHSMEndPoints is structure used for storing GET response from
+// REST API endpoint "/". This endpoint can be called using no-auth
+// or consumer-cert-auth connection
+type RHSMEndPoints struct {
+	Rel  string `json:"rel"`
+	Href string `json:"href"`
+}
+
+// GetServerEndpoints tries to get list of supported server endpoints
+func (rhsmClient *RHSMClient) GetServerEndpoints(clientInfo *ClientInfo) (*[]RHSMEndPoints, error) {
+	var rhsmEndPoints []RHSMEndPoints
+	var connection *RHSMConnection
+
+	var headers = make(map[string]string)
+	if clientInfo == nil {
+		clientInfo = &ClientInfo{"", "", ""}
+	}
+	clientInfo.xCorrelationId = createCorrelationId()
+
+	_, err := rhsmClient.GetConsumerUUID()
+	if err == nil {
+		connection = rhsmClient.ConsumerCertAuthConnection
+	} else {
+		// When no consumer has been installed, then we will
+		// try to use no-auth connection. When server is available,
+		// then this should work
+		connection = rhsmClient.NoAuthConnection
+	}
+
+	res, err := connection.request(
+		http.MethodGet,
+		"",
+		"",
+		"",
+		&headers,
+		nil,
+		clientInfo,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get server endpoints :%v", err)
+	}
+
+	defer func() {
+		// We can ignore error returning, by Close(), because we only
+		// read content of body
+		_ = res.Body.Close()
+	}()
+
+	resBody, err := getResponseBody(res)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal([]byte(*resBody), &rhsmEndPoints)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse server endpoints: %s", err)
+	}
+
+	return &rhsmEndPoints, nil
+}
+
 // RHSMStatus is structure used for storing GET response from REST API
 // endpoint "/status". This endpoint can be called using no-auth or
 // consumer-cert-auth connection
@@ -70,7 +131,7 @@ func (rhsmClient *RHSMClient) GetServerStatus(clientInfo *ClientInfo) (*RHSMStat
 		return nil, fmt.Errorf("unable to get server status :%v", err)
 	}
 
-	// Server can respond only with 200 or 500 status code
+	// Server can respond only with 200 or 500 status codes
 	if res.StatusCode == 500 {
 		var unregisterServerError UnregisterServerError
 		parseServerResponse(&unregisterServerError, res)

--- a/status_test.go
+++ b/status_test.go
@@ -6,6 +6,145 @@ import (
 	"testing"
 )
 
+const serverEndpointsResponse = `[ {
+  "rel" : "entitlements",
+  "href" : "/entitlements"
+}, {
+  "rel" : "subscriptions",
+  "href" : "/subscriptions"
+}, {
+  "rel" : "environments",
+  "href" : "/environments"
+}, {
+  "rel" : "roles",
+  "href" : "/roles"
+}, {
+  "rel" : "jobs",
+  "href" : "/jobs"
+}, {
+  "rel" : "activation_keys",
+  "href" : "/activation_keys"
+}, {
+  "rel" : "admin",
+  "href" : "/admin"
+}, {
+  "rel" : "pools",
+  "href" : "/pools"
+}, {
+  "rel" : "rules",
+  "href" : "/rules"
+}, {
+  "rel" : "owners",
+  "href" : "/owners"
+}, {
+  "rel" : "cdn",
+  "href" : "/cdn"
+}, {
+  "rel" : "{owner}",
+  "href" : "/hypervisors/{owner}"
+}, {
+  "rel" : "content_overrides",
+  "href" : "/consumers/{consumer_uuid}/content_overrides"
+}, {
+  "rel" : "content",
+  "href" : "/content"
+}, {
+  "rel" : "users",
+  "href" : "/users"
+}, {
+  "rel" : "products",
+  "href" : "/products"
+}, {
+  "rel" : "consumertypes",
+  "href" : "/consumertypes"
+}, {
+  "rel" : "consumers",
+  "href" : "/consumers"
+}, {
+  "rel" : "deleted_consumers",
+  "href" : "/deleted_consumers"
+}, {
+  "rel" : "distributor_versions",
+  "href" : "/distributor_versions"
+}, {
+  "rel" : "crl",
+  "href" : "/crl"
+}, {
+  "rel" : "{id}",
+  "href" : "/serials/{id}"
+}, {
+  "rel" : "status",
+  "href" : "/status"
+} ]`
+
+func TestGetServerEndpoints(t *testing.T) {
+	t.Parallel()
+	handlerCounter := 0
+
+	server := httptest.NewTLSServer(
+		// It is expected that GetServerStatus() will call only
+		// one REST API point
+		http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			// Increase number of calls
+			handlerCounter += 1
+
+			// Test request method
+			if req.Method != http.MethodGet {
+				t.Fatalf("extepected request method: %s, got: %s", http.MethodGet, req.Method)
+			}
+
+			// Test that requested URL is correct
+			expectedURL := "/"
+			reqURL := req.URL.String()
+			if reqURL != expectedURL {
+				t.Fatalf("expected request URL: '%s', got: '%s'", expectedURL, reqURL)
+			}
+
+			// Return code 200
+			rw.WriteHeader(200)
+			// Add some headers specific for candlepin server
+			rw.Header().Add("x-candlepin-request-uuid", "168e3687-8498-46b2-af0a-272583d4d4ba")
+			// Return empty body
+			_, _ = rw.Write([]byte(serverEndpointsResponse))
+		}))
+	defer server.Close()
+
+	// Create root directory for this test
+	tempDirFilePath := t.TempDir()
+
+	// Setup filesystem for the case, when system is only registered,
+	// but no entitlement cert/key has been installed yet
+	testingFiles, err := setupTestingFileSystem(
+		tempDirFilePath, false, false, false, false, true)
+	if err != nil {
+		t.Fatalf("unable to setup testing environment: %s", err)
+	}
+
+	rhsmClient, err := setupTestingRHSMClient(testingFiles, server)
+	if err != nil {
+		t.Fatalf("unable to setup testing rhsm client: %s", err)
+	}
+
+	serverEndpoints, err := rhsmClient.GetServerEndpoints(nil)
+	if err != nil {
+		t.Fatalf("getting server endpoints failed: %s", err)
+	}
+
+	if handlerCounter != 1 {
+		t.Fatalf("handler for getting server endpoints REST API pointed not called once, but called: %d",
+			handlerCounter)
+	}
+
+	// Check the existence of one endpoint
+	for _, endpoint := range *serverEndpoints {
+		if endpoint.Rel == "status" {
+			if endpoint.Href != "/status" {
+				t.Fatalf("endpoint href expected '/status', got: %s", endpoint.Href)
+			}
+		}
+	}
+}
+
 const serverStatusResponse = `{
   "mode" : "NORMAL",
   "modeReason" : null,


### PR DESCRIPTION
* Added function GetServerEndpoints that could be used for getting list of supported endpoints (not complete)
* It call GET /. It could be used as some basic ping, because this endpoint is available for no-auth connection