### PR TITLE
feat: Added functions for set/unset release

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -2,8 +2,9 @@ package rhsm2
 
 import (
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"os"
+
+	"github.com/rs/zerolog/log"
 )
 
 // writePemFile Tries to write content of PEM (cert or key) to file.
@@ -28,10 +29,6 @@ func writePemFile(filePath *string, pemFileContent *string, mode *os.FileMode) e
 	// Print content of cert using Fprint(), because
 	// the string contains formatting sequences like \n
 	_, err = fmt.Fprint(file, *pemFileContent)
-
-	if err != nil {
-		return err
-	}
 
 	if err != nil {
 		return err

--- a/config.go
+++ b/config.go
@@ -77,6 +77,9 @@ type RHSMConf struct {
 	// yumRepoFilePath is the file path of the redhat.repo file
 	yumRepoFilePath string
 
+	// dnfVarsReleaseFilePath specifies the file path to the release version information for DNF variables.
+	dnfVarsReleaseFilePath string
+
 	// syspurposeFilePath is the file path of the syspurpose.json file
 	syspurposeFilePath string
 
@@ -180,10 +183,11 @@ func IsValueAllowed(value *reflect.Value, allowedValues *string) (bool, error) {
 // RHSMConf structure
 func LoadRHSMConf(confFilePath string) (*RHSMConf, error) {
 	rhsmConf := &RHSMConf{
-		filePath:           confFilePath,
-		yumRepoFilePath:    DefaultRepoFilePath,
-		syspurposeFilePath: DefaultSystemPurposeFilePath,
-		osReleaseFilePath:  DefaultOsReleaseFilePath,
+		filePath:               confFilePath,
+		yumRepoFilePath:        DefaultRepoFilePath,
+		dnfVarsReleaseFilePath: DefaultDnfVarsReleaseFilePath,
+		syspurposeFilePath:     DefaultSystemPurposeFilePath,
+		osReleaseFilePath:      DefaultOsReleaseFilePath,
 	}
 
 	err := rhsmConf.load()

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -85,17 +85,18 @@ func copyFile(srcFilePath *string, dstFilePath *string, perm *os.FileMode) error
 // TestingFileSystem is structure holding information about file paths
 // used for testing
 type TestingFileSystem struct {
-	EtcDirPath            string
-	OsReleaseFilePath     string
-	CACertDirPath         string
-	ConsumerDirPath       string
-	EntitlementDirPath    string
-	ProductDirPath        string
-	ProductDefaultDirPath string
-	SyspurposeDirPath     string
-	SyspurposeFilePath    string
-	YumReposDirPath       string
-	YumRepoFilePath       string
+	EtcDirPath             string
+	OsReleaseFilePath      string
+	DnfVarsReleaseFilePath string
+	CACertDirPath          string
+	ConsumerDirPath        string
+	EntitlementDirPath     string
+	ProductDirPath         string
+	ProductDefaultDirPath  string
+	SyspurposeDirPath      string
+	SyspurposeFilePath     string
+	YumReposDirPath        string
+	YumRepoFilePath        string
 }
 
 // setupTestingFiles tries to copy and generate testing files to testing directories
@@ -222,6 +223,9 @@ func setupTestingDirectories(tempDirFilePath string, perm os.FileMode) (*Testing
 		return nil, err
 	}
 	testingFileSystem.EtcDirPath = *etcDirPath
+
+	// Set the file path for release dnf variable file
+	testingFileSystem.DnfVarsReleaseFilePath = filepath.Join(testingFileSystem.EtcDirPath, "dnf", "vars", "release")
 
 	// Create temporary directory for CA certificate
 	caCertDirPath, err := createDirectory(tempDirFilePath, "etc/rhsm/ca", perm)
@@ -369,9 +373,10 @@ func setupTestingRHSMClient(testingFiles *TestingFileSystem, server *httptest.Se
 
 	// Fill rhsm conf with fake data and temporary paths
 	rhsmClient.RHSMConf = &RHSMConf{
-		yumRepoFilePath:    testingFiles.YumRepoFilePath,
-		syspurposeFilePath: testingFiles.SyspurposeFilePath,
-		osReleaseFilePath:  testingFiles.OsReleaseFilePath,
+		yumRepoFilePath:        testingFiles.YumRepoFilePath,
+		syspurposeFilePath:     testingFiles.SyspurposeFilePath,
+		osReleaseFilePath:      testingFiles.OsReleaseFilePath,
+		dnfVarsReleaseFilePath: testingFiles.DnfVarsReleaseFilePath,
 		RHSM: RHSMConfRHSM{
 			ConsumerCertDir:       testingFiles.ConsumerDirPath,
 			EntitlementCertDir:    testingFiles.EntitlementDirPath,


### PR DESCRIPTION
* It is possible to set and unset release locally in dnf vars directory (`/etc/dnf/vars/releasever`).
* The RHSMClient has new public methods
  * `SetRelease(release string)`
  * `UnsetRelease()`
* When it is possible to set/unset release on the candlepin server, then the REST API call is called asynchronously.
* Added unit tests for new methods
* Converted some methods to non-public methods