### PR TITLE
feat: Use download content overrides as repo overrides

### DIFF
--- a/content.go
+++ b/content.go
@@ -65,7 +65,6 @@ type EntitlementContentJSON struct {
 // writeRepoFile tries to write map of products to repo file
 func (rhsmClient *RHSMClient) writeRepoFile(
 	productsMap map[int64][]EngineeringProduct,
-	contentOverrides map[string]map[string]string,
 ) error {
 	file := ini.Empty()
 
@@ -134,17 +133,6 @@ func (rhsmClient *RHSMClient) writeRepoFile(
 
 				// sslverifystatus
 				_, _ = section.NewKey("sslverifystatus", "1")
-
-				// Apply content overrides
-				if override, exists := contentOverrides[content.Name]; exists {
-					for key, value := range override {
-						_, err := section.NewKey(key, value)
-						if err != nil {
-							log.Error().Msgf("unable to apply content override for repository: %s", content.Name)
-							log.Error().Msgf("unable to add value: %v for key: %s: %s", value, key, err)
-						}
-					}
-				}
 			}
 		}
 	}
@@ -197,15 +185,13 @@ func (rhsmClient *RHSMClient) getEngineeringProducts() (map[int64][]EngineeringP
 
 // generateRepoFileFromInstalledEntitlementCerts tries to generate redhat.repo file
 // from installed entitlement certificate(s) and content overrides
-func (rhsmClient *RHSMClient) generateRepoFileFromInstalledEntitlementCerts(
-	contentOverrides map[string]map[string]string,
-) error {
+func (rhsmClient *RHSMClient) generateRepoFileFromInstalledEntitlementCerts() error {
 	engineeringProductsMap, err := rhsmClient.getEngineeringProducts()
 	if err != nil {
 		return err
 	}
 
-	return rhsmClient.writeRepoFile(engineeringProductsMap, contentOverrides)
+	return rhsmClient.writeRepoFile(engineeringProductsMap)
 }
 
 // getContentFromEntCertFile tries to load entitlement certificate from given file

--- a/content_overrides.go
+++ b/content_overrides.go
@@ -3,12 +3,18 @@ package rhsm2
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"net/http"
+
+	"github.com/rs/zerolog/log"
+	"gopkg.in/ini.v1"
 )
 
-// ContentOverride is structure containing information about content
-// override for given repository
+const dnf5ReposOverrideDirPath = "/etc/dnf/repos.override.d"
+const dnf5ReposOverrideFileName = "98-redhat.repo"
+const dnf5RedHatReposOverrideFilePath = dnf5ReposOverrideDirPath + "/" + dnf5ReposOverrideFileName
+
+// ContentOverride is a structure containing information about content
+// override for a given repository
 type ContentOverride struct {
 	Created      string `json:"created"`
 	Updated      string `json:"updated"`
@@ -66,7 +72,74 @@ func (rhsmClient *RHSMClient) getContentOverrides(info *ClientInfo) ([]ContentOv
 	return contentOverrides, nil
 }
 
-// createMapFromContentOverrides creates map with content overrides from list of
+// readContentOverridesFromDnf5RepoOverride tries to read content overrides from dnf5 repo override file
+// We try to read repo overrides using ini package. Hopefully, it will work without any issue.
+func readContentOverridesFromDnf5RepoOverride(filePath string) (map[string]map[string]string, error) {
+	repo, err := ini.Load(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]map[string]string)
+	for _, section := range repo.Sections() {
+		// Skip the DEFAULT section added by ini package
+		if section.Name() == ini.DefaultSection {
+			continue
+		}
+		sectionMap := make(map[string]string)
+		for _, key := range section.Keys() {
+			sectionMap[key.Name()] = key.Value()
+		}
+		result[section.Name()] = sectionMap
+	}
+	return result, nil
+}
+
+// writeContentOverridesToDnf5RepoOverride tries to write content overrides to dnf5 repo override file
+func writeContentOverridesToDnf5RepoOverride(contentOverrides []ContentOverride, filePath string) error {
+	// First, create empty ini file object
+	repo := ini.Empty()
+
+	// Convert the list of content overrides to a map
+	mapContentOverrides := createMapFromContentOverrides(contentOverrides)
+
+	// Fill ini file (repo file) with repo override from the map
+	for contentLabel, contentOverrideMap := range mapContentOverrides {
+		var section *ini.Section
+		var err error
+
+		if repo.HasSection(contentLabel) {
+			section = repo.Section(contentLabel)
+		} else {
+			section, err = repo.NewSection(contentLabel)
+			if err != nil {
+				return err
+			}
+		}
+		for contentName, contentValue := range contentOverrideMap {
+			var key *ini.Key
+			if section.HasKey(contentName) {
+				key = section.Key(contentName)
+			} else {
+				key, err = section.NewKey(contentName, contentValue)
+				if err != nil {
+					return err
+				}
+			}
+			key.SetValue(contentValue)
+		}
+	}
+
+	// Write repo override to the file
+	err := repo.SaveTo(filePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createMapFromContentOverrides creates the map with content overrides from the list of
 // content overrides returned from candlepin server
 func createMapFromContentOverrides(contentOverrides []ContentOverride) map[string]map[string]string {
 	mapContentOverrides := make(map[string]map[string]string)

--- a/content_overrides_test.go
+++ b/content_overrides_test.go
@@ -3,7 +3,9 @@ package rhsm2
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -310,6 +312,227 @@ func Test_createMapFromContentOverrides(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := createMapFromContentOverrides(tt.args.contentOverrides); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("createMapFromContentOverrides() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_writeContentOverridesToDnf5RepoOverride tests writing content overrides to DNF5 repo override file
+func Test_writeContentOverridesToDnf5RepoOverride(t *testing.T) {
+	type args struct {
+		contentOverrides []ContentOverride
+		fileContent      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"empty content overrides",
+			args{
+				contentOverrides: []ContentOverride{},
+				fileContent:      "",
+			},
+			false,
+		},
+		{
+			"single content override",
+			args{
+				contentOverrides: []ContentOverride{
+					{
+						ContentLabel: "awesome-os-801",
+						Created:      "2023-10-23T11:54:30+0000",
+						Updated:      "2023-11-23T11:54:30+0000",
+						Name:         "enabled",
+						Value:        "1",
+					},
+				},
+				fileContent: "[awesome-os-801]\n" +
+					"enabled = 1",
+			},
+			false,
+		},
+		{
+			"two content overrides for the same repo",
+			args{
+				contentOverrides: []ContentOverride{
+					{
+						ContentLabel: "awesome-os-801",
+						Created:      "2023-10-23T11:54:30+0000",
+						Updated:      "2023-11-23T11:54:30+0000",
+						Name:         "enabled",
+						Value:        "1",
+					},
+					{
+						ContentLabel: "awesome-os-801",
+						Created:      "2023-10-23T11:54:30+0000",
+						Updated:      "2023-11-23T11:54:30+0000",
+						Name:         "gpgcheck",
+						Value:        "0",
+					},
+				},
+				fileContent: "[awesome-os-801]\n" +
+					"enabled  = 1\n" +
+					"gpgcheck = 0",
+			},
+			false,
+		},
+		{
+			"two content overrides for two repos",
+			args{
+				contentOverrides: []ContentOverride{
+					{
+						ContentLabel: "awesome-os-801",
+						Created:      "2023-10-23T11:54:30+0000",
+						Updated:      "2023-11-23T11:54:30+0000",
+						Name:         "enabled",
+						Value:        "1",
+					},
+					{
+						ContentLabel: "cool-os-801",
+						Created:      "2023-10-23T11:54:30+0000",
+						Updated:      "2023-11-23T11:54:30+0000",
+						Name:         "gpgcheck",
+						Value:        "0",
+					},
+				},
+				fileContent: "[awesome-os-801]\n" +
+					"enabled = 1\n" +
+					"\n" +
+					"[cool-os-801]\n" +
+					"gpgcheck = 0",
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory for test
+			tempDir := t.TempDir()
+			filePath := tempDir + "/repo_overrides.toml"
+
+			err := writeContentOverridesToDnf5RepoOverride(tt.args.contentOverrides, filePath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("writeContentOverridesToDnf5RepoOverride() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Read the content of the file
+			fileBytes, err := os.ReadFile(filePath)
+			if err != nil && !tt.wantErr {
+				t.Errorf("failed to read file %s: %v", filePath, err)
+			}
+
+			// Compare the file content with expected content
+			fileContent := strings.TrimSpace(string(fileBytes))
+			expectedContent := strings.TrimSpace(tt.args.fileContent)
+			if fileContent != expectedContent {
+				t.Errorf("file content mismatch:\ngot:\n%s\n\nwant:\n%s", fileContent, expectedContent)
+			}
+
+		})
+	}
+}
+
+// Test_readContentOverridesFromDnf5RepoOverride tests reading content overrides from DNF5 repo override file
+func Test_readContentOverridesFromDnf5RepoOverride(t *testing.T) {
+	type args struct {
+		fileContent string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]map[string]string
+		wantErr bool
+	}{
+		{
+			"empty file",
+			args{
+				fileContent: "",
+			},
+			make(map[string]map[string]string),
+			false,
+		},
+		{
+			"single content override",
+			args{
+				fileContent: "[awesome-os-801]\n" +
+					"enabled = 1",
+			},
+			map[string]map[string]string{"awesome-os-801": {"enabled": "1"}},
+			false,
+		},
+		{
+			"two content overrides for the same repo",
+			args{
+				fileContent: "[awesome-os-801]\n" +
+					"enabled  = 1\n" +
+					"gpgcheck = 0",
+			},
+			map[string]map[string]string{"awesome-os-801": {"enabled": "1", "gpgcheck": "0"}},
+			false,
+		},
+		{
+			"two content overrides for two repos",
+			args{
+				fileContent: "[awesome-os-801]\n" +
+					"enabled = 1\n" +
+					"\n" +
+					"[cool-os-801]\n" +
+					"gpgcheck = 0",
+			},
+			map[string]map[string]string{
+				"awesome-os-801": {"enabled": "1"},
+				"cool-os-801":    {"gpgcheck": "0"},
+			},
+			false,
+		},
+		{
+			"file with comments",
+			args{
+				fileContent: "# This is a comment\n" +
+					"[awesome-os-801]\n" +
+					"enabled = 1",
+			},
+			map[string]map[string]string{"awesome-os-801": {"enabled": "1"}},
+			false,
+		},
+		{
+			"non-existent file",
+			args{
+				fileContent: "",
+			},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory for test
+			tempDir := t.TempDir()
+			filePath := tempDir + "/repo_overrides.toml"
+
+			// For non-existent file test, don't create the file
+			if tt.name != "non-existent file" {
+				// Write test content to file
+				err := os.WriteFile(filePath, []byte(tt.args.fileContent), 0644)
+				if err != nil {
+					t.Fatalf("failed to write test file: %v", err)
+				}
+			}
+
+			// For non-existent file test, use a path that doesn't exist
+			if tt.name == "non-existent file" {
+				filePath = tempDir + "/non_existent.toml"
+			}
+
+			got, err := readContentOverridesFromDnf5RepoOverride(filePath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readContentOverridesFromDnf5RepoOverride() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("readContentOverridesFromDnf5RepoOverride() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/content_test.go
+++ b/content_test.go
@@ -191,8 +191,7 @@ func TestWriteRepoFile(t *testing.T) {
 		t.Fatalf("unable to setup testing rhsm client: %s", err)
 	}
 
-	contentOverrides := make(map[string]map[string]string)
-	err = rhsmClient.generateRepoFileFromInstalledEntitlementCerts(contentOverrides)
+	err = rhsmClient.generateRepoFileFromInstalledEntitlementCerts()
 
 	if err != nil {
 		t.Fatalf("unable to generate '%s': %s", testingFiles.YumRepoFilePath, err)
@@ -226,8 +225,7 @@ func TestWriteRepoFileNoEntCert(t *testing.T) {
 		t.Fatalf("unable to setup testing rhsm client: %s", err)
 	}
 
-	contentOverrides := make(map[string]map[string]string)
-	err = rhsmClient.generateRepoFileFromInstalledEntitlementCerts(contentOverrides)
+	err = rhsmClient.generateRepoFileFromInstalledEntitlementCerts()
 
 	if err != nil {
 		t.Fatalf("when no entitlement certificate installed, error returned: %s", err)

--- a/register.go
+++ b/register.go
@@ -3,13 +3,14 @@ package rhsm2
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/rs/zerolog/log"
 )
 
 // SystemFacts is collection of system facts necessary during registration
@@ -432,7 +433,6 @@ func (rhsmClient *RHSMClient) enableContent(getContentOverrides bool, info *Clie
 
 	// Create empty maps of products and content overrides for corner cases
 	engineeringProducts := make(map[int64][]EngineeringProduct)
-	contentOverrides := make(map[string]map[string]string)
 
 	// Try to get entitlement certs and keys from channel
 	entCertKeysResult, ok := <-entCertKeysChan
@@ -444,7 +444,7 @@ func (rhsmClient *RHSMClient) enableContent(getContentOverrides bool, info *Clie
 		engineeringProducts = createProductMap(entCertKeysResult.entCertKeyJSONList)
 	}
 
-	// Try to get content overrides from channel
+	// Try to get content overrides from the channel
 	if getContentOverrides {
 		contentOverridesResult, ok := <-contentOverridesChan
 		if ok {
@@ -452,14 +452,20 @@ func (rhsmClient *RHSMClient) enableContent(getContentOverrides bool, info *Clie
 				return contentOverridesResult.err
 			}
 			if len(contentOverridesResult.contentOverridesList) > 0 {
-				contentOverrides = createMapFromContentOverrides(contentOverridesResult.contentOverridesList)
+				err := writeContentOverridesToDnf5RepoOverride(
+					contentOverridesResult.contentOverridesList,
+					dnf5RedHatReposOverrideFilePath,
+				)
+				if err != nil {
+					log.Warn().Msgf("unable to write content overrides to repo file: %s", err)
+				}
 			}
 		}
 	}
 
-	// Write content to redhat.repo file
+	// Write content to the redhat.repo file
 	if len(engineeringProducts) > 0 {
-		err := rhsmClient.writeRepoFile(engineeringProducts, contentOverrides)
+		err := rhsmClient.writeRepoFile(engineeringProducts)
 		if err != nil {
 			return fmt.Errorf("unable to write repo file: %s: %s",
 				rhsmClient.RHSMConf.yumRepoFilePath, err)


### PR DESCRIPTION
* When content override is downloaded from candlepin server, the the content override is saved as repo override in the `/etc/dnf/repo.override.d/98-redhat.repo`
* Content overrides are not written directly to `redhat.repo` file, but content overrides are stored out of `redhat.repo` file and there is no need to use some other JSOn file file
* Added unit tests for new code