### PR TITLE
feat: Better setting of User-Agent HTTP header

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,6 +11,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// UserAgentInfo holds information about the current client connected
+// to the candlepin server
+type UserAgentInfo struct {
+	AppName      string
+	Distribution string
+}
+
 // RHSMClient contains information about client. It can hold up to 3 different
 // type of connections, but usually it is necessary to use only consumerCertAuthConnection.
 // The noAuthConnection is used only during registration process, when no consumer
@@ -18,6 +25,7 @@ import (
 // "Base Auth", because it is actually noAuthConnection with special HTTP header.
 // entitlementCertAuthConnection could be used for communication with CDN.
 type RHSMClient struct {
+	UserAgent                     *UserAgentInfo
 	RHSMConf                      *RHSMConf
 	noAuthConnection              *RHSMConnection
 	consumerCertAuthConnection    *RHSMConnection
@@ -27,14 +35,14 @@ type RHSMClient struct {
 var singletonRhsmClient *RHSMClient
 var once sync.Once
 
-// GetRHSMClient tries to return instance of RHSMClient. If the instance
-// already exist, then existing instance is returned. The confFilePath
+// GetRHSMClient tries to return the instance of RHSMClient. If the instance
+// already exists, then the existing instance is returned. The confFilePath
 // is used only in the first call of the function. It is just ignored
 // in any other next call.
-func GetRHSMClient(confFilePath *string) (*RHSMClient, error) {
+func GetRHSMClient(appName *string, confFilePath *string) (*RHSMClient, error) {
 	var err error
 	once.Do(func() {
-		singletonRhsmClient, err = createRHSMClient(confFilePath)
+		singletonRhsmClient, err = createRHSMClient(appName, confFilePath)
 	})
 	if err != nil {
 		return nil, err
@@ -43,7 +51,7 @@ func GetRHSMClient(confFilePath *string) (*RHSMClient, error) {
 }
 
 // createRHSMClient tries to create structure holding information about RHSM client
-func createRHSMClient(confFilePath *string) (*RHSMClient, error) {
+func createRHSMClient(appName *string, confFilePath *string) (*RHSMClient, error) {
 	var err error
 	var rhsmConf *RHSMConf
 
@@ -58,10 +66,23 @@ func createRHSMClient(confFilePath *string) (*RHSMClient, error) {
 	}
 
 	rhsmClient := &RHSMClient{
+		UserAgent: &UserAgentInfo{
+			AppName:      *appName,
+			Distribution: "",
+		},
 		RHSMConf:                      rhsmConf,
 		noAuthConnection:              nil,
 		consumerCertAuthConnection:    nil,
 		entitlementCertAuthConnection: nil,
+	}
+
+	// Try to get information about the Linux distribution from /etc/os-release
+	content, err := os.ReadFile(rhsmClient.RHSMConf.osReleaseFilePath)
+	if err == nil {
+		release, err := parseOSRelease(&content)
+		if err == nil {
+			rhsmClient.UserAgent.Distribution = release.ID + "/" + release.VersionID
+		}
 	}
 
 	// Try to create connection without authentication

--- a/client_test.go
+++ b/client_test.go
@@ -6,9 +6,10 @@ import "testing"
 // successfully created using given configuration file
 func TestCreateRHSMClient(t *testing.T) {
 	t.Parallel()
+	appName := "unit-tester/0.1"
 	confFilePath := "./testdata/etc/rhsm/rhsm.conf"
 
-	rhsmClient, err := createRHSMClient(&confFilePath)
+	rhsmClient, err := createRHSMClient(&appName, &confFilePath)
 
 	if err != nil {
 		t.Fatalf("unable to create RHSM client: %s", err)
@@ -37,13 +38,14 @@ func TestCreateRHSMClient(t *testing.T) {
 // TestGetRHSMClient test the case, when client tries to get
 // RHSMClient multiple times. It should be still the same instance
 func TestGetRHSMClient(t *testing.T) {
+	appName := "unit-tester/0.1"
 	confFilePath := "./testdata/etc/rhsm/rhsm.conf"
 
-	rhsmClient01, err := GetRHSMClient(&confFilePath)
+	rhsmClient01, err := GetRHSMClient(&appName, &confFilePath)
 	if err != nil {
 		t.Fatalf("unable to get instance of RHSM client: %s", err)
 	} else {
-		rhsmClient02, err := GetRHSMClient(&confFilePath)
+		rhsmClient02, err := GetRHSMClient(&appName, &confFilePath)
 		if err != nil {
 			t.Fatalf("unable to get another instance of RHSM client: %s", err)
 		} else {

--- a/connection.go
+++ b/connection.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/henvic/httpretty"
 	"github.com/jeandeaual/go-locale"
-	"github.com/jirihnidek/rhsm2/constants"
 	"github.com/rs/zerolog/log"
 )
 
@@ -51,55 +50,39 @@ func createCorrelationId() string {
 	return uuid.New().String()
 }
 
-// UserAgentInfo holds information about current client connected
-// to candlepin server
-type UserAgentInfo struct {
-	BaseString string
-	Command    string
-}
-
-// ClientInfo holds information about current client triggering
-// given HTTP request. Information in this structure could not
+// RequestMetadata holds information about the current client triggering
+// a given HTTP request. Information in this structure could not
 // be stored in rhsmClient, because RHSM client could be also
-// rhsm2.service providing D-Bus API and each D-Bus client
-// communicating over D-Bus can have different preferences
-// (e.g. locale).
-type ClientInfo struct {
-	Locale         string
-	DBusSender     string
-	xCorrelationId string
+// systemd .service providing e.g., D-Bus API or Varlink API
+// and each D-Bus or Varlink client can have different preferences
+// (e.g., locale).
+type RequestMetadata struct {
+	Locale        *string
+	IPCSender     *string
+	CorrelationId *string
 }
 
-var (
-	// UserAgent is the HTTP header used in each HTTP request
-	UserAgent = UserAgentInfo{
-		"RHSM/" + constants.ApiVersion,
-		"",
+func sanitizeMetadata(metadata *RequestMetadata) *RequestMetadata {
+	if metadata == nil {
+		metadata = &RequestMetadata{nil, nil, nil}
 	}
-)
-
-// SetUserAgentCmd set command of UserAgent
-func SetUserAgentCmd(userAgentCmd string) {
-	UserAgent.Command = userAgentCmd
-}
-
-// String returns textual representation of UserAgent
-func (userAgent UserAgentInfo) String() string {
-	if userAgent.Command != "" {
-		return userAgent.BaseString + " (cmd=" + userAgent.Command + ")"
+	if metadata.CorrelationId == nil {
+		correlationID := createCorrelationId()
+		metadata.CorrelationId = &correlationID
 	}
-	return userAgent.BaseString
+	return metadata
 }
 
 // request tries to call HTTP request to candlepin server
 func (connection *RHSMConnection) request(
+	userAgent *UserAgentInfo,
 	method string,
 	path string,
 	query string,
 	fragment string,
 	headers *map[string]string,
 	body *[]byte,
-	clientInfo *ClientInfo,
+	metadata *RequestMetadata,
 ) (*http.Response, error) {
 
 	requestURL := url.URL{
@@ -143,18 +126,22 @@ func (connection *RHSMConnection) request(
 	}
 
 	// Always add HTTP header UserAgent
-	if clientInfo != nil && clientInfo.DBusSender != "" {
+	if metadata != nil && metadata.IPCSender != nil {
 		req.Header.Add(
 			"User-Agent",
-			fmt.Sprintf("%s (dbus_sender=%s)", UserAgent.String(), clientInfo.DBusSender),
+			fmt.Sprintf("%s (trigger-by: %s) %s",
+				userAgent.AppName, *metadata.IPCSender, userAgent.Distribution),
 		)
 	} else {
-		req.Header.Add("User-Agent", UserAgent.String())
+		req.Header.Add(
+			"User-Agent",
+			fmt.Sprintf("%s %s", userAgent.AppName, userAgent.Distribution),
+		)
 	}
 
 	// Always add HTTP header Accept-Language
-	if clientInfo != nil && clientInfo.Locale != "" {
-		req.Header.Add("Accept-Language", clientInfo.Locale)
+	if metadata != nil && metadata.Locale != nil {
+		req.Header.Add("Accept-Language", *metadata.Locale)
 	} else {
 		userLocale, err := locale.GetLocale()
 		if err != nil || userLocale == "" {
@@ -164,10 +151,13 @@ func (connection *RHSMConnection) request(
 		}
 	}
 
-	// Try to add HTTP header X-Correlation-Id
-	if clientInfo != nil && clientInfo.xCorrelationId != "" {
-		req.Header.Add("X-Correlation-Id", clientInfo.xCorrelationId)
+	// Try to add HTTP header Correlation-Id
+	if metadata != nil && metadata.CorrelationId != nil {
+		req.Header.Add("Correlation-ID", *metadata.CorrelationId)
 	}
+
+	// Add HTTP header Request-ID: Unique identifier for a single HTTP request
+	req.Header.Add("Request-ID", uuid.New().String())
 
 	// If "Accept" header is not specified, then request JSON in response
 	var acceptExists = false

--- a/connection_test.go
+++ b/connection_test.go
@@ -18,33 +18,13 @@ func TestCreateXCorrelationID(t *testing.T) {
 	}
 }
 
-// TestUserAgentString test the case, when client has not set command of UserAgent
-// String() method should return default value
-func TestUserAgentString(t *testing.T) {
-	userAgentStr := UserAgent.String()
-	expectedUserAgent := "RHSM/2.0"
-	if userAgentStr != expectedUserAgent {
-		t.Fatalf("expected UserAgent: \"%s\", got: \"%s\"", expectedUserAgent, userAgentStr)
-	}
-}
-
-// TestSetUserAgentCmd test the case, when client set command of UserAgent
-func TestSetUserAgentCmd(t *testing.T) {
-	SetUserAgentCmd("foo-cmd")
-	userAgentStr := UserAgent.String()
-	expectedUserAgent := "RHSM/2.0 (cmd=foo-cmd)"
-	if userAgentStr != expectedUserAgent {
-		t.Fatalf("expected UserAgent: \"%s\", got: \"%s\"", expectedUserAgent, userAgentStr)
-	}
-}
-
-// TestGetServerStatusClientInfo test the case, when we try to
-// call some REST API call with not empty ClientInfo structure
-func TestGetServerStatusClientInfo(t *testing.T) {
+// TestGetServerStatusMetadata test the case, when we try to
+// call some REST API call with not empty RequestMetadata structure
+func TestGetServerStatusMetadata(t *testing.T) {
 	handlerCounter := 0
 	expectedLocale := "de-DE"
-	expectedDBusSender := "foo-dbus-client"
-	expectedUserAgentCmd := "tester"
+	expectedIPCSender := "foo-varlink-client"
+	expectedCorrelationId := "test-correlation-id"
 
 	server := httptest.NewTLSServer(
 		// It is expected that GetServerStatus() will call only
@@ -55,7 +35,7 @@ func TestGetServerStatusClientInfo(t *testing.T) {
 
 			// Test request method
 			if req.Method != http.MethodGet {
-				t.Fatalf("extepected request method: %s, got: %s", http.MethodGet, req.Method)
+				t.Fatalf("expected request method: %s, got: %s", http.MethodGet, req.Method)
 			}
 
 			// Test that requested URL is correct
@@ -66,9 +46,13 @@ func TestGetServerStatusClientInfo(t *testing.T) {
 			}
 
 			// Test that HTTP headers are correct
-			xCorrelationId := req.Header.Get("X-Correlation-ID")
-			if xCorrelationId == "" {
-				t.Fatalf("X-Correlation-ID is empty string")
+			CorrelationId := req.Header.Get("Correlation-ID")
+			if CorrelationId == "" {
+				t.Fatalf("Correlation-ID is empty string")
+			}
+			RequestId := req.Header.Get("Request-ID")
+			if RequestId == "" {
+				t.Fatalf("Request-ID is empty string")
 			}
 			locale := req.Header.Get("Accept-Language")
 			if locale != expectedLocale {
@@ -76,9 +60,8 @@ func TestGetServerStatusClientInfo(t *testing.T) {
 			}
 			userAgent := req.Header.Get("User-Agent")
 			expectedUserAgent := fmt.Sprintf(
-				"RHSM/2.0 (cmd=%s) (dbus_sender=%s)",
-				expectedUserAgentCmd,
-				expectedDBusSender,
+				"unit-tester/0.1 (trigger-by: %s) foo-linux/10.0",
+				expectedIPCSender,
 			)
 			if userAgent != expectedUserAgent {
 				t.Fatalf("expected User-Agent HTTP header: %s, got: %s", expectedUserAgent, userAgent)
@@ -109,10 +92,8 @@ func TestGetServerStatusClientInfo(t *testing.T) {
 		t.Fatalf("unable to setup testing rhsm client: %s", err)
 	}
 
-	SetUserAgentCmd(expectedUserAgentCmd)
-
-	clientInfo := ClientInfo{expectedLocale, expectedDBusSender, ""}
-	serverStatus, err := rhsmClient.GetServerStatus(&clientInfo)
+	metadata := RequestMetadata{&expectedLocale, &expectedIPCSender, &expectedCorrelationId}
+	serverStatus, err := rhsmClient.GetServerStatus(&metadata)
 	if err != nil {
 		t.Fatalf("getting server status failed: %s", err)
 	}
@@ -183,8 +164,9 @@ func TestCreateHTTPsClientProxyFromConf(t *testing.T) {
 	rhsmClient.RHSMConf.Server.ProxyUser = "user"
 	rhsmClient.RHSMConf.Server.ProxyPassword = "secret"
 
-	clientInfo := ClientInfo{"", "", "66bf0b7a-aaae-4b31-a7bf-bc22052afebf"}
-	serverStatus, err := rhsmClient.GetServerStatus(&clientInfo)
+	correlationID := "66bf0b7a-aaae-4b31-a7bf-bc22052afebf"
+	metadata := RequestMetadata{nil, nil, &correlationID}
+	serverStatus, err := rhsmClient.GetServerStatus(&metadata)
 	if err != nil {
 		t.Fatalf("getting server status failed: %s", err)
 	}

--- a/content_overrides.go
+++ b/content_overrides.go
@@ -24,7 +24,7 @@ type ContentOverride struct {
 }
 
 // getContentOverrides tries to get content overrides from server
-func (rhsmClient *RHSMClient) getContentOverrides(info *ClientInfo) ([]ContentOverride, error) {
+func (rhsmClient *RHSMClient) getContentOverrides(info *RequestMetadata) ([]ContentOverride, error) {
 	var contentOverrides []ContentOverride
 
 	consumerUuid, err := rhsmClient.GetConsumerUUID()
@@ -40,6 +40,7 @@ func (rhsmClient *RHSMClient) getContentOverrides(info *ClientInfo) ([]ContentOv
 		return nil, fmt.Errorf("unable to get consumer cert auth connection: %v", err)
 	}
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodGet,
 		"consumers/"+*consumerUuid+"/content_overrides",
 		"",

--- a/entitlement.go
+++ b/entitlement.go
@@ -104,7 +104,7 @@ func (rhsmClient *RHSMClient) getInstalledEntitlementCertificateKeys() (map[int6
 // When it is possible to get entitlement certificate(s), then write these certificate(s) to file.
 // Note: candlepin server returns only one SCA entitlement certificate ATM, but REST API allows to
 // return more entitlement certificates.
-func (rhsmClient *RHSMClient) getSCAEntitlementCertificates(clientInfo *ClientInfo) ([]EntitlementCertificateKeyJSON, error) {
+func (rhsmClient *RHSMClient) getSCAEntitlementCertificates(metadata *RequestMetadata) ([]EntitlementCertificateKeyJSON, error) {
 	consumerUuid, err := rhsmClient.GetConsumerUUID()
 
 	if err != nil {
@@ -118,13 +118,14 @@ func (rhsmClient *RHSMClient) getSCAEntitlementCertificates(clientInfo *ClientIn
 		return nil, fmt.Errorf("unable to get consumer cert auth connection: %v", err)
 	}
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodGet,
 		"consumers/"+*consumerUuid+"/certificates",
 		"",
 		"",
 		&headers,
 		nil,
-		clientInfo)
+		metadata)
 
 	if err != nil {
 		return nil, fmt.Errorf("getting entitlement certificates failed: %s", err)

--- a/environment.go
+++ b/environment.go
@@ -34,7 +34,7 @@ func (rhsmClient *RHSMClient) GetEnvironments(
 	username string,
 	password string,
 	organization string,
-	clientInfo *ClientInfo,
+	metadata *RequestMetadata,
 ) ([]Environment, error) {
 	var environments []Environment
 	var headers = make(map[string]string)
@@ -42,23 +42,21 @@ func (rhsmClient *RHSMClient) GetEnvironments(
 	headers["username"] = username
 	headers["password"] = password
 
-	if clientInfo == nil {
-		clientInfo = &ClientInfo{"", "", ""}
-	}
-	clientInfo.xCorrelationId = createCorrelationId()
+	metadata = sanitizeMetadata(metadata)
 
 	connection, err := rhsmClient.getNoAuthConnection()
 	if err != nil {
 		return environments, fmt.Errorf("unable to get no-auth connection: %v", err)
 	}
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodGet,
 		"owners/"+organization+"/environments",
 		"",
 		"",
 		&headers,
 		nil,
-		clientInfo)
+		metadata)
 
 	if err != nil {
 		return environments, fmt.Errorf("unable to get list of environments: %s", err)

--- a/organization.go
+++ b/organization.go
@@ -32,7 +32,7 @@ type OrganizationData struct {
 func (rhsmClient *RHSMClient) GetOrgs(
 	username string,
 	password string,
-	clientInfo *ClientInfo,
+	metadata *RequestMetadata,
 ) ([]OrganizationData, error) {
 	var organizations []OrganizationData
 	var headers = make(map[string]string)
@@ -40,10 +40,7 @@ func (rhsmClient *RHSMClient) GetOrgs(
 	headers["username"] = username
 	headers["password"] = password
 
-	if clientInfo == nil {
-		clientInfo = &ClientInfo{"", "", ""}
-	}
-	clientInfo.xCorrelationId = createCorrelationId()
+	metadata = sanitizeMetadata(metadata)
 
 	connection, err := rhsmClient.getNoAuthConnection()
 	if err != nil {
@@ -51,13 +48,14 @@ func (rhsmClient *RHSMClient) GetOrgs(
 	}
 
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodGet,
 		"users/"+username+"/owners",
 		"",
 		"",
 		&headers,
 		nil,
-		clientInfo)
+		metadata)
 	if err != nil {
 		return organizations, fmt.Errorf("unable to get list of org IDs: %s", err)
 	}

--- a/register.go
+++ b/register.go
@@ -144,7 +144,7 @@ type RegisterOptions struct {
 // registerSystem tries to register system
 func (rhsmClient *RHSMClient) registerSystem(
 	registerOptions *RegisterOptions,
-	clientInfo *ClientInfo,
+	metadata *RequestMetadata,
 ) (*ConsumerData, error) {
 	var headers = make(map[string]string)
 	var query string
@@ -224,13 +224,14 @@ func (rhsmClient *RHSMClient) registerSystem(
 	}
 
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodPost,
 		"consumers",
 		query,
 		"",
 		&headers,
 		&body,
-		clientInfo)
+		metadata)
 
 	if err != nil {
 		return nil, err
@@ -304,7 +305,7 @@ func (rhsmClient *RHSMClient) registerSystem(
 		// there can be some content override associated with one of
 		// activation keys
 		getContentOverrides := registerOptions.activationKeys != nil
-		err = rhsmClient.enableContent(getContentOverrides, clientInfo)
+		err = rhsmClient.enableContent(getContentOverrides, metadata)
 		if err != nil {
 			return nil, err
 		}
@@ -321,19 +322,16 @@ func (rhsmClient *RHSMClient) RegisterOrgActivationKeys(
 	org *string,
 	activationKeys []string,
 	options *map[string]string,
-	clientInfo *ClientInfo,
+	metadata *RequestMetadata,
 ) (*ConsumerData, error) {
 	var registerOptions RegisterOptions
 
-	if clientInfo == nil {
-		clientInfo = &ClientInfo{"", "", ""}
-	}
-	clientInfo.xCorrelationId = createCorrelationId()
+	metadata = sanitizeMetadata(metadata)
 
 	registerOptions.organization = org
 	registerOptions.activationKeys = &activationKeys
 
-	return rhsmClient.registerSystem(&registerOptions, clientInfo)
+	return rhsmClient.registerSystem(&registerOptions, metadata)
 }
 
 // RegisterUsernamePassword tries to register system using username and password
@@ -341,7 +339,7 @@ func (rhsmClient *RHSMClient) RegisterUsernamePassword(
 	username *string,
 	password *string,
 	options *map[string]string,
-	clientInfo *ClientInfo,
+	metadata *RequestMetadata,
 ) (*ConsumerData, error) {
 	var registerOptions RegisterOptions
 	var environments []string
@@ -366,12 +364,9 @@ func (rhsmClient *RHSMClient) RegisterUsernamePassword(
 	registerOptions.organization = &org
 	registerOptions.environments = &environments
 
-	if clientInfo == nil {
-		clientInfo = &ClientInfo{"", "", ""}
-	}
-	clientInfo.xCorrelationId = createCorrelationId()
+	metadata = sanitizeMetadata(metadata)
 
-	return rhsmClient.registerSystem(&registerOptions, clientInfo)
+	return rhsmClient.registerSystem(&registerOptions, metadata)
 }
 
 // createProductMap tries to create map of entitlement certificates
@@ -405,7 +400,7 @@ type ContentOverridesResult struct {
 // enableContent tries to get SCA entitlement certificate and generate redhat.repo from these
 // certificates. Note: candlepin returns only one SCA certificate, but it returns it
 // in the list. Thus, in theory more certificates could be returned.
-func (rhsmClient *RHSMClient) enableContent(getContentOverrides bool, info *ClientInfo) error {
+func (rhsmClient *RHSMClient) enableContent(getContentOverrides bool, info *RequestMetadata) error {
 	var waitGroup sync.WaitGroup
 
 	// Try to get SCA entitlement certificate and key asynchronously

--- a/release.go
+++ b/release.go
@@ -192,6 +192,7 @@ func (rhsmClient *RHSMClient) getListingFile(listingPath string) (*string, error
 	}
 
 	resp, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodGet,
 		listingPath,
 		"",
@@ -318,7 +319,7 @@ type Release struct {
 
 // setReleaseOnServer tries to set the release on the candlepin server only (not on the host in the variable
 // file in /etc/dnf/vars/).
-func (rhsmClient *RHSMClient) setReleaseOnServer(clientInfo *ClientInfo, release string) error {
+func (rhsmClient *RHSMClient) setReleaseOnServer(metadata *RequestMetadata, release string) error {
 	consumerUuid, err := rhsmClient.GetConsumerUUID()
 
 	if err != nil {
@@ -327,10 +328,7 @@ func (rhsmClient *RHSMClient) setReleaseOnServer(clientInfo *ClientInfo, release
 
 	var headers = make(map[string]string)
 
-	if clientInfo == nil {
-		clientInfo = &ClientInfo{"", "", ""}
-	}
-	clientInfo.xCorrelationId = createCorrelationId()
+	metadata = sanitizeMetadata(metadata)
 
 	headers["Content-type"] = "application/json"
 	consumerData := Release{
@@ -346,13 +344,14 @@ func (rhsmClient *RHSMClient) setReleaseOnServer(clientInfo *ClientInfo, release
 		return fmt.Errorf("unable to get consumer cert auth connection: %v", err)
 	}
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodPut,
 		"consumers/"+*consumerUuid,
 		"",
 		"",
 		&headers,
 		&body,
-		clientInfo,
+		metadata,
 	)
 
 	if err != nil {
@@ -367,7 +366,7 @@ func (rhsmClient *RHSMClient) setReleaseOnServer(clientInfo *ClientInfo, release
 }
 
 // GetReleaseFromServer tries to get the latest release from the candlepin server.
-func (rhsmClient *RHSMClient) GetReleaseFromServer(clientInfo *ClientInfo) (string, error) {
+func (rhsmClient *RHSMClient) GetReleaseFromServer(metadata *RequestMetadata) (string, error) {
 	consumerUuid, err := rhsmClient.GetConsumerUUID()
 
 	if err != nil {
@@ -376,23 +375,21 @@ func (rhsmClient *RHSMClient) GetReleaseFromServer(clientInfo *ClientInfo) (stri
 
 	var headers = make(map[string]string)
 
-	if clientInfo == nil {
-		clientInfo = &ClientInfo{"", "", ""}
-	}
-	clientInfo.xCorrelationId = createCorrelationId()
+	metadata = sanitizeMetadata(metadata)
 
 	connection, err := rhsmClient.getCertAuthConnection()
 	if err != nil {
 		return "", fmt.Errorf("unable to get consumer cert auth connection: %v", err)
 	}
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodGet,
 		"consumers/"+*consumerUuid+"/release",
 		"",
 		"",
 		&headers,
 		nil,
-		clientInfo,
+		metadata,
 	)
 
 	if err != nil {
@@ -441,9 +438,9 @@ func (rhsmClient *RHSMClient) getReleaseTags() ([]string, error) {
 	return requiredTags, nil
 }
 
-// GetCdnReleases tries to get the list of available releases from CDN. The list of releases is
+// GetCdnReleases tries to get the list of available releases from CDN. The list of releases
 // should include only unique values of releases. There should not be any duplicates.
-func (rhsmClient *RHSMClient) GetCdnReleases(clientInfo *ClientInfo) (map[string]struct{}, error) {
+func (rhsmClient *RHSMClient) GetCdnReleases(metadata *RequestMetadata) (map[string]struct{}, error) {
 	// If the connection to the repository does not exist, return error
 	_, err := rhsmClient.getEntitlementCertAuthConnection()
 	if err != nil {

--- a/status.go
+++ b/status.go
@@ -17,15 +17,13 @@ type RHSMEndPoints struct {
 }
 
 // GetServerEndpoints tries to get list of supported server endpoints
-func (rhsmClient *RHSMClient) GetServerEndpoints(clientInfo *ClientInfo) (*[]RHSMEndPoints, error) {
+func (rhsmClient *RHSMClient) GetServerEndpoints(metadata *RequestMetadata) (*[]RHSMEndPoints, error) {
 	var rhsmEndPoints []RHSMEndPoints
 	var connection *RHSMConnection
 
 	var headers = make(map[string]string)
-	if clientInfo == nil {
-		clientInfo = &ClientInfo{"", "", ""}
-	}
-	clientInfo.xCorrelationId = createCorrelationId()
+
+	metadata = sanitizeMetadata(metadata)
 
 	_, err := rhsmClient.GetConsumerUUID()
 	if err == nil {
@@ -44,13 +42,14 @@ func (rhsmClient *RHSMClient) GetServerEndpoints(clientInfo *ClientInfo) (*[]RHS
 	}
 
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodGet,
 		"",
 		"",
 		"",
 		&headers,
 		nil,
-		clientInfo,
+		metadata,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get server endpoints :%v", err)
@@ -105,15 +104,13 @@ type RHSMStatus struct {
 
 // GetServerStatus tries to get status from the server. This
 // method is possible to call, when server is connected or not
-func (rhsmClient *RHSMClient) GetServerStatus(clientInfo *ClientInfo) (*RHSMStatus, error) {
+func (rhsmClient *RHSMClient) GetServerStatus(metadata *RequestMetadata) (*RHSMStatus, error) {
 	var rhsmStatus RHSMStatus
 	var connection *RHSMConnection
 
 	var headers = make(map[string]string)
-	if clientInfo == nil {
-		clientInfo = &ClientInfo{"", "", ""}
-	}
-	clientInfo.xCorrelationId = createCorrelationId()
+
+	metadata = sanitizeMetadata(metadata)
 
 	_, err := rhsmClient.GetConsumerUUID()
 	if err == nil {
@@ -132,13 +129,14 @@ func (rhsmClient *RHSMClient) GetServerStatus(clientInfo *ClientInfo) (*RHSMStat
 	}
 
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodGet,
 		"status",
 		"",
 		"",
 		&headers,
 		nil,
-		clientInfo,
+		metadata,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get server status :%v", err)

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -411,6 +411,12 @@ func setupTestingRHSMClient(testingFiles *TestingFileSystem, server *httptest.Se
 	// Create instance of RHSM client
 	rhsmClient := RHSMClient{}
 
+	// Set user agent command to "unit-tester"
+	rhsmClient.UserAgent = &UserAgentInfo{
+		AppName:      "unit-tester/0.1",
+		Distribution: "foo-linux/10.0",
+	}
+
 	// Fill rhsm conf with fake data and temporary paths
 	rhsmClient.RHSMConf = &RHSMConf{
 		yumRepoFilePath:        testingFiles.YumRepoFilePath,

--- a/unregister.go
+++ b/unregister.go
@@ -110,7 +110,7 @@ func (rhsmClient *RHSMClient) Clean() error {
 }
 
 // Unregister tries to unregister system
-func (rhsmClient *RHSMClient) Unregister(clientInfo *ClientInfo) error {
+func (rhsmClient *RHSMClient) Unregister(metadata *RequestMetadata) error {
 	consumerUuid, err := rhsmClient.GetConsumerUUID()
 
 	if err != nil {
@@ -119,23 +119,21 @@ func (rhsmClient *RHSMClient) Unregister(clientInfo *ClientInfo) error {
 
 	var headers = make(map[string]string)
 
-	if clientInfo == nil {
-		clientInfo = &ClientInfo{"", "", ""}
-	}
-	clientInfo.xCorrelationId = createCorrelationId()
+	metadata = sanitizeMetadata(metadata)
 
 	connection, err := rhsmClient.getCertAuthConnection()
 	if err != nil {
 		return fmt.Errorf("unable to get consumer cert auth connection: %v", err)
 	}
 	res, err := connection.request(
+		rhsmClient.UserAgent,
 		http.MethodDelete,
 		"consumers/"+*consumerUuid,
 		"",
 		"",
 		&headers,
 		nil,
-		clientInfo,
+		metadata,
 	)
 
 	// When we are not able to call REST API call, then cancel registration process.


### PR DESCRIPTION
* Refactored code to be more readable and reliable
* The basic information about User-Agent is set, when `RHSMClient` is created
* Moved information about basic `User-Agent` to `RHSMClient` structure
* Renamed `ClientInfo` to `Metadata` to follow Varlink API spec and the `ClientInfo` was little bit confusing
* Added `Request-ID` HTTP header
* Better handling of correlation ID and renamed the header from `X-Correlation-Id` to `Correlation-ID` to follow RFC
* Updated several unit tests