### PR TITLE
fix: When SetRelease("") is called, then delete release file

### DIFF
--- a/release.go
+++ b/release.go
@@ -239,6 +239,7 @@ func (rhsmClient *RHSMClient) setDnfVarsRelease(release string) error {
 			log.Warn().Msgf("unable to close file: %s", err)
 		}
 	}(releaseFile)
+
 	_, err = releaseFile.WriteString(release)
 	if err != nil {
 		return err
@@ -249,8 +250,17 @@ func (rhsmClient *RHSMClient) setDnfVarsRelease(release string) error {
 
 // SetRelease tries to set the release on the host in the variable file /etc/dnf/vars/releasever.
 // It also tries to set the release on the candlepin server. The set release on the server is done
-// asynchronously.
+// asynchronously. When the release is set to "", then delete the release file.
 func (rhsmClient *RHSMClient) SetRelease(release string, metadata *RequestMetadata) error {
+	// When the release is empty, then try to delete the release file.
+	if release == "" {
+		err := rhsmClient.UnsetRelease()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	err := rhsmClient.setDnfVarsRelease(release)
 	if err != nil {
 		return err

--- a/release_test.go
+++ b/release_test.go
@@ -1041,6 +1041,15 @@ func Test_SetRelease(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			name:           "successful set release to '' on registered system (unset)",
+			releaseVer:     "",
+			setupFiles:     true,
+			setupHTTP:      true,
+			statusCode:     204,
+			serverResponse: ``,
+			wantErr:        false,
+		},
+		{
 			name:           "server error on registered system",
 			releaseVer:     "11.5",
 			setupFiles:     true,
@@ -1052,6 +1061,13 @@ func Test_SetRelease(t *testing.T) {
 		{
 			name:       "set on unregistered system",
 			releaseVer: "11.5",
+			setupFiles: false,
+			setupHTTP:  false,
+			wantErr:    false,
+		},
+		{
+			name:       "set to '' on unregistered system (unset)",
+			releaseVer: "",
 			setupFiles: false,
 			setupHTTP:  false,
 			wantErr:    false,
@@ -1103,15 +1119,23 @@ func Test_SetRelease(t *testing.T) {
 			}
 
 			if !tt.wantErr {
-				content, err := os.ReadFile(testingFiles.DnfVarsReleaseFilePath)
-				if err != nil {
-					t.Errorf("unable to read release version file: %s", err)
-					return
-				}
-				gotContent := string(content)
-				if gotContent != tt.releaseVer {
-					t.Errorf("unexpected content of release version file: got %s, want %s",
-						gotContent, tt.releaseVer)
+				if tt.releaseVer != "" {
+					content, err := os.ReadFile(testingFiles.DnfVarsReleaseFilePath)
+					if err != nil {
+						t.Errorf("unable to read release version file: %s", err)
+						return
+					}
+					gotContent := string(content)
+					if gotContent != tt.releaseVer {
+						t.Errorf("unexpected content of release version file: got %s, want %s",
+							gotContent, tt.releaseVer)
+					}
+				} else {
+					_, err = os.Stat(testingFiles.DnfVarsReleaseFilePath)
+					fileExists := !os.IsNotExist(err)
+					if fileExists == true {
+						t.Errorf("Release file exists after setting release to ''")
+					}
 				}
 			}
 		})


### PR DESCRIPTION
* When `SetRelease()` was called with release equal to "", then empty string was written to file and empty release was sent to candlepin server, but the release file should be deleted in this case.
* Extended unit test for this case