### PR TITLE
fix: Do not try to use connection with not valid consumer cert

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -29,6 +30,7 @@ type RHSMClient struct {
 	RHSMConf                      *RHSMConf
 	noAuthConnection              *RHSMConnection
 	consumerCertAuthConnection    *RHSMConnection
+	consumerCertLastModTime       time.Time
 	entitlementCertAuthConnection *RHSMConnection
 }
 

--- a/connection.go
+++ b/connection.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/henvic/httpretty"
@@ -344,17 +345,44 @@ func (rhsmClient *RHSMClient) createNoAuthConnection(
 	return nil
 }
 
+// Try to close the connection
+func closeConnection(connection *RHSMConnection) {
+	if connection != nil {
+		log.Debug().Msgf("closing connection %v", connection)
+		connection.Client.CloseIdleConnections()
+	}
+}
+
 // getCertAuthConnection tries to get the current consumer cert auth connection. When the connection
 // does not exist, it creates a new one using the provided configuration.
 func (rhsmClient *RHSMClient) getCertAuthConnection() (*RHSMConnection, error) {
+	consumerCertFilePath := filepath.Join(rhsmClient.RHSMConf.RHSM.ConsumerCertDir, "cert.pem")
+
+	// Try to get the current consumer cert auth connection
 	if rhsmClient.consumerCertAuthConnection != nil {
-		return rhsmClient.consumerCertAuthConnection, nil
+		// Check if the consumer cert file has been modified
+		fileInfo, err := os.Stat(consumerCertFilePath)
+		if err != nil {
+			closeConnection(rhsmClient.consumerCertAuthConnection)
+			return nil, fmt.Errorf("consumer certificate %s does not exists", consumerCertFilePath)
+		}
+		modTime := fileInfo.ModTime()
+		if modTime.After(rhsmClient.consumerCertLastModTime) {
+			log.Info().Msgf("consumer cert file %s has been modified", consumerCertFilePath)
+			closeConnection(rhsmClient.consumerCertAuthConnection)
+			rhsmClient.consumerCertAuthConnection = nil
+		} else {
+			// It is probably not necessary to create a new connection
+			return rhsmClient.consumerCertAuthConnection, nil
+		}
 	}
+
+	log.Debug().Msgf("trying to create a new consumer cert auth connection")
 
 	hostname := &rhsmClient.RHSMConf.Server.Hostname
 	port := &rhsmClient.RHSMConf.Server.Port
 	prefix := &rhsmClient.RHSMConf.Server.Prefix
-	consumerCertFilePath := filepath.Join(rhsmClient.RHSMConf.RHSM.ConsumerCertDir, "cert.pem")
+
 	if _, err := os.Stat(consumerCertFilePath); err != nil {
 		return nil, fmt.Errorf("consumer certificate %s does not exists", consumerCertFilePath)
 	}
@@ -392,6 +420,17 @@ func (rhsmClient *RHSMClient) createCertAuthConnection(
 		ServerHostname: hostname,
 		ServerPort:     port,
 		ServerPrefix:   prefix,
+	}
+
+	// Get the time of the last change of certFilePath
+	fileInfo, err := os.Stat(*certFilePath)
+	if err != nil {
+		log.Warn().Msgf("unable to get file info for %s: %v", *certFilePath, err)
+		rhsmClient.consumerCertLastModTime = time.Time{}
+	} else {
+		modTime := fileInfo.ModTime()
+		log.Debug().Msgf("certificate file %s last modified at: %s", *certFilePath, modTime.Format(time.RFC3339))
+		rhsmClient.consumerCertLastModTime = modTime
 	}
 
 	return nil

--- a/connection_test.go
+++ b/connection_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -251,6 +254,159 @@ func TestGetCertAuthConnectionRegistered(t *testing.T) {
 	// Verify connection has transport configured
 	if connection.Client == nil {
 		t.Fatalf("connection http client should not be nil")
+	}
+}
+
+// TestGetCertAuthConnectionUnRegistered test the case when we try to get connection
+// using consumer certificate authentication for the system that was unregistered
+func TestGetCertAuthConnectionUnRegistered(t *testing.T) {
+	t.Parallel()
+
+	// Create root directory for this test
+	tempDirFilePath := t.TempDir()
+
+	// Setup filesystem with consumer certificate and key
+	testingFiles, err := setupTestingFileSystem(
+		tempDirFilePath,
+		true,
+		true,
+		false,
+		false,
+		true)
+	if err != nil {
+		t.Fatalf("unable to setup testing environment: %s", err)
+	}
+
+	server := httptest.NewTLSServer(
+		http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			// Verify that client certificate was provided
+			if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
+				t.Fatalf("expected client certificate, but none was provided")
+			}
+
+			// Return code 200
+			rw.WriteHeader(200)
+			_, _ = rw.Write([]byte("OK"))
+		}))
+	defer server.Close()
+
+	rhsmClient, err := setupTestingRHSMClient(testingFiles, server, nil)
+	if err != nil {
+		t.Fatalf("unable to setup testing rhsm client: %s", err)
+	}
+
+	// Get cert auth connection
+	connection, err := rhsmClient.getCertAuthConnection()
+	if err != nil {
+		t.Fatalf("failed to create cert auth connection: %s", err)
+	}
+
+	if connection == nil {
+		t.Fatalf("connection should not be nil")
+	}
+
+	// Verify connection has transport configured
+	if connection.Client == nil {
+		t.Fatalf("connection http client should not be nil")
+	}
+
+	// Try to mimic unregistering the system and delete consumer certificate and key
+	consumerCertFilePath := filepath.Join(rhsmClient.RHSMConf.RHSM.ConsumerCertDir, "cert.pem")
+	err = os.Remove(consumerCertFilePath)
+	if err != nil {
+		t.Fatalf("failed to delete consumer certificate: %s", err)
+	}
+	consumerKeyFilePath := filepath.Join(rhsmClient.RHSMConf.RHSM.ConsumerCertDir, "key.pem")
+	err = os.Remove(consumerKeyFilePath)
+	if err != nil {
+		t.Fatalf("failed to delete consumer key: %s", err)
+	}
+
+	// Try to get cert auth connection
+	newConnection, err := rhsmClient.getCertAuthConnection()
+	if err == nil {
+		t.Fatalf("It should fail to create cert auth connection, when there is no consumer certificate")
+	}
+
+	if newConnection != nil {
+		t.Fatalf("It should not be able to create cert auth connection, when there is no consumer certificate")
+	}
+}
+
+// TestGetCertAuthConnectionReRegistered test the case when we try to get connection
+// using consumer certificate authentication for the system that was unregistered
+// and then it was re-registered
+func TestGetCertAuthConnectionReRegistered(t *testing.T) {
+	t.Parallel()
+
+	// Create root directory for this test
+	tempDirFilePath := t.TempDir()
+
+	// Setup filesystem with consumer certificate and key
+	testingFiles, err := setupTestingFileSystem(
+		tempDirFilePath,
+		true,
+		true,
+		false,
+		false,
+		true)
+	if err != nil {
+		t.Fatalf("unable to setup testing environment: %s", err)
+	}
+
+	server := httptest.NewTLSServer(
+		http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			// Verify that client certificate was provided
+			if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
+				t.Fatalf("expected client certificate, but none was provided")
+			}
+
+			// Return code 200
+			rw.WriteHeader(200)
+			_, _ = rw.Write([]byte("OK"))
+		}))
+	defer server.Close()
+
+	rhsmClient, err := setupTestingRHSMClient(testingFiles, server, nil)
+	if err != nil {
+		t.Fatalf("unable to setup testing rhsm client: %s", err)
+	}
+
+	// Get cert auth connection
+	connection, err := rhsmClient.getCertAuthConnection()
+	if err != nil {
+		t.Fatalf("failed to create cert auth connection: %s", err)
+	}
+
+	if connection == nil {
+		t.Fatalf("connection should not be nil")
+	}
+
+	// Verify connection has transport configured
+	if connection.Client == nil {
+		t.Fatalf("connection http client should not be nil")
+	}
+
+	// Try to mimic re-registering the system by changing last modified time of consumer certificate and key
+	consumerCertFilePath := filepath.Join(rhsmClient.RHSMConf.RHSM.ConsumerCertDir, "cert.pem")
+	err = os.Chtimes(consumerCertFilePath, time.Now().Add(+time.Second), time.Now().Add(+time.Second))
+	if err != nil {
+		t.Fatalf("failed to change last modified time of consumer certificate: %s", err)
+	}
+	consumerKeyFilePath := filepath.Join(rhsmClient.RHSMConf.RHSM.ConsumerCertDir, "key.pem")
+	err = os.Chtimes(consumerKeyFilePath, time.Now().Add(+time.Second), time.Now().Add(+time.Second))
+	if err != nil {
+		t.Fatalf("failed to change last modified time of consumer key: %s", err)
+	}
+
+	// Get cert auth connection
+	newConnection, err := rhsmClient.getCertAuthConnection()
+	if err != nil {
+		t.Fatalf("failed to create cert auth connection: %s", err)
+	}
+
+	if connection == newConnection {
+		t.Fatalf("connection should be different after re-registering the system")
 	}
 }
 

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -463,6 +463,12 @@ func setupTestingRHSMClient(testingFiles *TestingFileSystem, server *httptest.Se
 			ServerPrefix:   &prefix,
 		}
 
+		consumerCertFilePath := filepath.Join(rhsmClient.RHSMConf.RHSM.ConsumerCertDir, "cert.pem")
+		fileInfo, _ := os.Stat(consumerCertFilePath)
+		if fileInfo != nil {
+			rhsmClient.consumerCertLastModTime = fileInfo.ModTime()
+		}
+
 	}
 	if cdn != nil {
 		// Get the hostname, port and prefix from the fake server


### PR DESCRIPTION
* When rhsm2 is used by long running service providing some API (Varlink API, D-Bus, etc.) and some other application like subscription-manager unregister or re-register the system, then consumer certificate and key loaded by service to memory cannot be used for communication. Thus, it is necessary to check before any REST API call if consumer cert has changed since creating connection
* RHSMConnection holds the time, when connection was created and if the consumer certificate has been changed after this time, then the connection is dropped.
* Added two unit tests for these two cases. First unit tests covers the situation, when consumer certificate was deleted and second unit tests covers the situation, when system was re-registered
* Modified test helper for unit tests according the change
* TODO:
   * Modify entitlement connection in similar way in another commit and PR
   * Handle 410 response of candlepin server, when the consumer was deleted server side e.g. according long inactictivity