### PR TITLE
feat: Extend error and add there not matching tags

### DIFF
--- a/release.go
+++ b/release.go
@@ -119,14 +119,16 @@ func readOsReleaseFile(osReleaseFilePath string) (*OSRelease, error) {
 	return release, nil
 }
 
-// NoInstalledProductsMatchesOsReleaseError is returned when no installed product certificate matches the
+// NoInstalledProductCertMatchesOsReleaseError is returned when no installed product certificate matches the
 // current release of the Linux distribution.
-type NoInstalledProductsMatchesOsReleaseError struct {
-	OsReleaseTag string
+type NoInstalledProductCertMatchesOsReleaseError struct {
+	OsReleaseTag    string
+	NotMatchingTags []string
 }
 
-func (e *NoInstalledProductsMatchesOsReleaseError) Error() string {
-	return fmt.Sprintf("no installed product certificate matches os release: %s", e.OsReleaseTag)
+func (e *NoInstalledProductCertMatchesOsReleaseError) Error() string {
+	return fmt.Sprintf("no tag of installed product certificate(s) %v matches os release: %s",
+		e.NotMatchingTags, e.OsReleaseTag)
 }
 
 // filterInstalledProductsUsingOSRelease tries to filter the list of installed product certificates
@@ -173,6 +175,7 @@ func (rhsmClient *RHSMClient) filterInstalledProductsUsingOSRelease(installedPro
 	osReleaseTag := strings.ToLower(release.ID) + "-" + release.VersionMajor
 
 	var filteredProducts []InstalledProduct
+	var notMatchingTags = make(map[string]struct{})
 	for _, product := range installedProducts {
 		found := false
 		// Look for tags that match the current OS release version
@@ -182,10 +185,12 @@ func (rhsmClient *RHSMClient) filterInstalledProductsUsingOSRelease(installedPro
 				filteredProducts = append(filteredProducts, product)
 				found = true
 				break
+			} else {
+				notMatchingTags[tag] = struct{}{}
 			}
 		}
 		if !found {
-			log.Warn().Msgf(
+			log.Info().Msgf(
 				"skipping product: %s; its tags: %s do not match os release: %s",
 				product.filePath,
 				product.providedTags,
@@ -195,7 +200,14 @@ func (rhsmClient *RHSMClient) filterInstalledProductsUsingOSRelease(installedPro
 	}
 
 	if len(filteredProducts) == 0 {
-		return filteredProducts, &NoInstalledProductsMatchesOsReleaseError{OsReleaseTag: osReleaseTag}
+		var notMatchingTagsList []string
+		for tag := range notMatchingTags {
+			notMatchingTagsList = append(notMatchingTagsList, tag)
+		}
+		return filteredProducts, &NoInstalledProductCertMatchesOsReleaseError{
+			OsReleaseTag:    osReleaseTag,
+			NotMatchingTags: notMatchingTagsList,
+		}
 	}
 
 	return filteredProducts, nil
@@ -513,7 +525,7 @@ func (rhsmClient *RHSMClient) GetCdnReleases(metadata *RequestMetadata) (map[str
 	// used for getting the list of available releases
 	releaseTags, err := rhsmClient.getReleaseTags()
 	if err != nil {
-		log.Debug().Msgf("unable to get release tags: %s", err)
+		log.Warn().Msgf("unable to get release tags: %s", err)
 		return nil, err
 	}
 	log.Debug().Msgf("release tags: %v", releaseTags)

--- a/release_test.go
+++ b/release_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -518,9 +519,29 @@ func Test_GetCdnReleasesNotMatchingOsReleaseAndProductCert(t *testing.T) {
 		t.Fatalf("unexpected number of CDN handlers called, expected 0, got %d", cdnHandlerCounter)
 	}
 
-	var noInstalledProductsMatchesOsReleaseError *NoInstalledProductsMatchesOsReleaseError
+	var noInstalledProductsMatchesOsReleaseError *NoInstalledProductCertMatchesOsReleaseError
 	if !errors.As(err, &noInstalledProductsMatchesOsReleaseError) {
 		t.Fatalf("unexpected error returned, when no installed product matches os release: %s", err)
+	}
+
+	if noInstalledProductsMatchesOsReleaseError.NotMatchingTags == nil {
+		t.Fatalf("unexpected nil not matching tags list")
+	}
+
+	if noInstalledProductsMatchesOsReleaseError.OsReleaseTag != "fedora-44" {
+		t.Fatalf("unexpected os release tag, expected fedora-44, got %s",
+			noInstalledProductsMatchesOsReleaseError.OsReleaseTag)
+	}
+
+	if (len(noInstalledProductsMatchesOsReleaseError.NotMatchingTags)) != 2 {
+		t.Fatalf("unexpected number of not matching tags, expected 2, got %d",
+			len(noInstalledProductsMatchesOsReleaseError.NotMatchingTags))
+	}
+
+	expectedNotMatchingTags := []string{"rhel-10", "rhel-10-x86_64"}
+	if !reflect.DeepEqual(noInstalledProductsMatchesOsReleaseError.NotMatchingTags, expectedNotMatchingTags) {
+		t.Fatalf("unexpected not matching tags, expected %v, got %v",
+			expectedNotMatchingTags, noInstalledProductsMatchesOsReleaseError.NotMatchingTags)
 	}
 
 	expectedReleases := map[string]struct{}{}


### PR DESCRIPTION
* `NoInstalledProductCertMatchesOsReleaseError` contained os-release, but it did not contain no matching tags from installed products. Thus, such error was not too useful
* Changed error message representing this error
* Changed severity of log messages
* Other similar erros in release.go contained keyword cert and this one error did not contain this key, which could be confusing. The original error name also contained small typo