### PR TITLE
feat: Added error for reading os-release file

### DIFF
--- a/release.go
+++ b/release.go
@@ -108,15 +108,25 @@ func parseOSRelease(content *[]byte) (*OSRelease, error) {
 func readOsReleaseFile(osReleaseFilePath string) (*OSRelease, error) {
 	content, err := os.ReadFile(osReleaseFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read %s: %s", osReleaseFilePath, err)
+		return nil, &ReadOSReleaseError{OsReleaseFilePath: osReleaseFilePath, Err: err}
 	}
 
 	release, err := parseOSRelease(&content)
 	if err != nil {
-		return nil, err
+		return nil, &ReadOSReleaseError{OsReleaseFilePath: osReleaseFilePath, Err: err}
 	}
 
 	return release, nil
+}
+
+// ReadOSReleaseError is returned when unable to read the OS release file.
+type ReadOSReleaseError struct {
+	OsReleaseFilePath string
+	Err               error
+}
+
+func (e *ReadOSReleaseError) Error() string {
+	return fmt.Sprintf("unable to read os release file %s: %s", e.OsReleaseFilePath, e.Err)
 }
 
 // NoInstalledProductCertMatchesOsReleaseError is returned when no installed product certificate matches the

--- a/release_test.go
+++ b/release_test.go
@@ -1624,3 +1624,68 @@ HOME_URL="https://www.redhat.com/"`,
 		})
 	}
 }
+
+func Test_readOsReleaseFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		want     OSRelease
+		wantErr  bool
+	}{
+		{
+			name:     "valid RHEL os-release file",
+			filePath: "testdata/etc/os-release",
+			want: OSRelease{
+				ID:           "rhel",
+				VersionID:    "10.0",
+				VersionMajor: "10",
+				VersionMinor: "0",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "valid Fedora os-release file",
+			filePath: "testdata/etc/os-release-fedora",
+			want: OSRelease{
+				ID:           "fedora",
+				VersionID:    "44",
+				VersionMajor: "44",
+				VersionMinor: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "invalid os-release file",
+			filePath: "testdata/etc/os-release-invalid",
+			want:     OSRelease{},
+			wantErr:  true,
+		},
+		{
+			name:     "non-existent file",
+			filePath: "testdata/etc/non-existent-file",
+			want:     OSRelease{},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readOsReleaseFile(tt.filePath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readOsReleaseFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				var readOsReleaseError *ReadOSReleaseError
+				if errors.As(err, &readOsReleaseError) {
+					_ = readOsReleaseError.Error()
+					return
+				}
+				t.Errorf("expected readOsReleaseFile() returns ReadOSReleaseError, got %v", err)
+			}
+			if got != nil && *got != tt.want {
+				t.Errorf("readOsReleaseFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/testdata/etc/os-release-invalid
+++ b/testdata/etc/os-release-invalid
@@ -1,0 +1,5 @@
+NAME=Red Hat Enterprise Linux
+VERSION=11.5 (Foo)
+INVALID_LINE
+ID=rhel
+foo: bar


### PR DESCRIPTION
* When it is not possible to read or parse `os-release` file, then `ReadOSReleaseError` error is returned from `readOsReleaseFile` or any function using `readOsReleaseFile`
* Added unit test for this new error and added example of invalid `os-release` file